### PR TITLE
Introducing typed-throws

### DIFF
--- a/Sources/FunctionTools/Call.swift
+++ b/Sources/FunctionTools/Call.swift
@@ -16,18 +16,18 @@ import Foundation
 ///
 /// For example:
 /// ```swift
-/// let someFunctions: [BlindCallback] = [
-///     { print("Hello") },
-///     { print("World!") },
+/// let someFunctions: [ThrowingBlindCallback<SendError>] = [
+///     { try send("Hello") },
+///     { try send("World!") },
 /// ]
 ///
-/// someFunctions.forEach(call)
+/// try someFunctions.forEach(call)
 /// ```
 ///
 /// - Parameter callee: The function to call
 /// - Throws: Anything `callee` throws
 @inlinable
-public func call(_ callee: ThrowingBlindCallback) rethrows {
+public func call<Failure: Error>(_ callee: ThrowingBlindCallback<Failure>) rethrows {
     try callee()
 }
 
@@ -75,13 +75,13 @@ public func call<T>(_ inputGenerator: Generator<T>) -> T { inputGenerator() }
 ///
 /// For example:
 /// ```swift
-/// let values = generators.map(call)
+/// let values = try failableGenerators.map(call)
 /// ```
 ///
 /// - Parameter inputGenerator: The function which generates a value
 /// - Throws: Anything `inputGenerator` throws
 @inlinable
-public func call<T>(_ inputGenerator: ThrowingGenerator<T>) rethrows -> T { try inputGenerator() }
+public func call<T, Failure: Error>(_ inputGenerator: ThrowingGenerator<T, Failure>) throws(Failure) -> T { try inputGenerator() }
 
 
 
@@ -109,7 +109,7 @@ public func call<T>(_ generator: AsyncGenerator<T>) async -> T { await generator
 ///
 /// For example:
 /// ```swift
-/// async let values = asyncGenerators.map(call).collect()
+/// async let values = try asyncFailableGenerators.map(call).collect()
 /// ```
 ///
 /// - Parameter inputGenerator: The function which generates a value

--- a/Sources/FunctionTools/Function types.swift
+++ b/Sources/FunctionTools/Function types.swift
@@ -21,7 +21,7 @@ public typealias BlindCallback = () -> Void
 /// It can also throw an error if necessary.
 ///
 /// - Throws: Some error, if a problem occurred while provessing the callback
-public typealias ThrowingBlindCallback = () throws -> Void
+public typealias ThrowingBlindCallback<Failure: Error> = () throws(Failure) -> Void
 
 
 
@@ -37,7 +37,7 @@ public typealias Callback<Result> = (_ result: Result) -> Void
 ///
 /// - Parameter result: The result of the function that this one is passed to
 /// - Throws: Some error, if a problem occurred while provessing the callback
-public typealias ThrowingCallback<Result> = (_ result: Result) throws -> Void
+public typealias ThrowingCallback<Result, Failure: Error> = (_ result: Result) throws(Failure) -> Void
 
 
 
@@ -57,7 +57,7 @@ public typealias Transformer<Original, Transformed> = (_ original: Original) -> 
 /// - Parameter original: The value before transformation
 /// - Returns: The value after transformation
 /// - Throws: Some error, if a problem occurred during transformation
-public typealias ThrowingTransformer<Original, Transformed> = (_ original: Original) throws -> Transformed
+public typealias ThrowingTransformer<Original, Transformed, Failure: Error> = (_ original: Original) throws(Failure) -> Transformed
 
 
 
@@ -75,7 +75,7 @@ public typealias Filter<Element> = Transformer<Element, Bool>
 /// - Parameter original: Each element in a sequence
 /// - Returns: `true` iff the given element should be in the filtered view of the sequence
 /// - Throws: Some error, if a problem occurred during filtering
-public typealias ThrowingFilter<Element> = ThrowingTransformer<Element, Bool>
+public typealias ThrowingFilter<Element, Failure: Error> = ThrowingTransformer<Element, Bool, Failure>
 
 
 
@@ -94,7 +94,7 @@ public typealias Generator<Output> = () -> Output
 ///
 /// - Returns: Something it was meant to generate
 /// - Throws: Some error, if a problem occurred during generating
-public typealias ThrowingGenerator<Output> = () throws -> Output
+public typealias ThrowingGenerator<Output, Failure: Error> = () throws(Failure) -> Output
 
 
 
@@ -142,7 +142,7 @@ public typealias Reducer<Collection, Reduction> = (_ reduction: inout Reduction,
 ///     - element: Each element in a sequence
 ///
 /// - Throws: Some error, if a problem occurred during reducing
-public typealias ThrowingReducer<Collection, Reduction> = (_ reduction: inout Reduction, _ element: Collection.Element) throws -> Void
+public typealias ThrowingReducer<Collection, Reduction, Failure: Error> = (_ reduction: inout Reduction, _ element: Collection.Element) throws(Failure) -> Void
     where Collection: Swift.Sequence
 
 
@@ -171,7 +171,7 @@ public typealias AllocationReducer<Collection, Reduction> = (_ reduction: Reduct
 /// - Returns: The result of reducing the sequence with the current element
 ///
 /// - Throws: Some error, if a problem occurred during reducing
-public typealias ThrowingAllocationReducer<Collection, Reduction> = (_ reduction: Reduction, _ element: Collection.Element) throws -> Reduction
+public typealias ThrowingAllocationReducer<Collection, Reduction, Failure: Error> = (_ reduction: Reduction, _ element: Collection.Element) throws(Failure) -> Reduction
     where Collection: Swift.Sequence
 
 
@@ -198,7 +198,7 @@ public typealias Combinator<InputA, InputB, Output> = (_ a: InputA, _ b: InputB)
 /// - Returns: The result of combining the two inputs
 ///
 /// - Throws: Some error, if a problem occurred during combination
-public typealias ThrowingCombinator<InputA, InputB, Output> = (_ a: InputA, _ b: InputB) throws -> Output
+public typealias ThrowingCombinator<InputA, InputB, Output, Failure: Error> = (_ a: InputA, _ b: InputB) throws(Failure) -> Output
 
 
 

--- a/Tests/FunctionToolsTests/`call` tests.swift
+++ b/Tests/FunctionToolsTests/`call` tests.swift
@@ -36,14 +36,14 @@ struct CallThrowingGeneratorTests {
     
     @Test("Returns the value produced by a non-throwing `ThrowingGenerator<Int>`")
     func nonThrowingGeneratorReturnsInt() throws {
-        let result: Int = try call({ try throwingValue_67_nothrows } as ThrowingGenerator<Int>)
+        let result: Int = try call({ () throws(Error) in try throwingValue_67_nothrows } as ThrowingGenerator<Int, Error>)
         #expect(result == 67)
     }
     
     
     @Test("Returns the value produced by a non-throwing `ThrowingGenerator<String>`")
     func nonThrowingGeneratorReturnsString() throws {
-        let result = try call({ try throwingValue_snafu_nothrows } as ThrowingGenerator<String>)
+        let result = try call({ () throws(Error) in try throwingValue_snafu_nothrows } as ThrowingGenerator<String, Error>)
         #expect(result == "snafu")
     }
     
@@ -51,7 +51,7 @@ struct CallThrowingGeneratorTests {
     @Test("Returns the value produced by a non-throwing `ThrowingGenerator<Point>`")
     func nonThrowingGeneratorReturnsStruct() throws {
         let expected = Point(x: 2, y: 9)
-        let result = try call({ expected } as ThrowingGenerator<Point>)
+        let result = try call({ () throws(Error) in expected } as ThrowingGenerator<Point, Error>)
         #expect(result == expected)
     }
     
@@ -60,7 +60,7 @@ struct CallThrowingGeneratorTests {
     func throwingGeneratorPropagatesError() {
         // `echo` must rethrow without wrapping or swallowing the original error.
         #expect(throws: TestError.self) {
-            try call({ throw TestError() } as ThrowingGenerator<Int>)
+            try call({ () throws(TestError) in throw TestError() } as ThrowingGenerator<Int, TestError>)
         }
     }
     
@@ -68,7 +68,7 @@ struct CallThrowingGeneratorTests {
     @Test("Propagates an error thrown by a `ThrowingGenerator<String>`")
     func throwingStringGeneratorPropagatesError() {
         #expect(throws: TestError.self) {
-            try call({ throw TestError() } as ThrowingGenerator<String>)
+            try call({ () throws(TestError) in throw TestError() } as ThrowingGenerator<String, TestError>)
         }
     }
     
@@ -76,19 +76,20 @@ struct CallThrowingGeneratorTests {
     @Test("Can flatten a `[ThrowingGenerator<Int>]` via `map(echo)`")
     func flattenCollectionOfGenerators() throws {
         // This is the canonical usage shown in the documentation.
-        let generators: [ThrowingGenerator<Int>] = [{ 1 }, { 2 }, { 3 }]
+        let generators: [ThrowingGenerator<Int, Error>] = [{ 1 }, { 2 }, { 3 }]
         let values = try generators.map(call)
         #expect(values == [1, 2, 3])
     }
     
     
+    @available(macOS 15, *)
     @Test("Stops at the first throwing generator when used with `map(echo)`")
     func mapStopsAtFirstThrowingGenerator() {
         var callCount = 0
-        let generators: [ThrowingGenerator<Int>] = [
-            { callCount += 1; return 1 },
-            { throw TestError() },
-            { callCount += 1; return 3 },   // must never be reached
+        let generators: [ThrowingGenerator<Int, Error>] = [ // TODO: Set this to `TestError` once the compiler doesn't crash doing that
+            { () throws(TestError) in callCount += 1; return 1 },
+            { () throws(TestError) in throw TestError() },
+            { () throws(TestError) in callCount += 1; return 3 },   // must never be reached
         ]
         #expect(throws: TestError.self) {
             _ = try generators.map(call)
@@ -112,22 +113,22 @@ struct CallThrowingGeneratorTests {
 struct CallAsyncGeneratorTests {
     
     
-    @Test("Returns the value produced by a non-throwing `AsyncThrowingGenerator<Int, _>`")
-    func nonThrowingAsyncGeneratorReturnsInt() async throws {
+    @Test("Returns the value produced by a non-throwing `AsyncGenerator<Int>`")
+    func nonThrowingAsyncGeneratorReturnsInt() async {
         let result = await call({ 77 } as AsyncGenerator<Int>)
         #expect(result == 77)
     }
     
     
-    @Test("Returns the value produced by a non-throwing `AsyncThrowingGenerator<String, _>`")
-    func nonThrowingAsyncGeneratorReturnsString() async throws {
+    @Test("Returns the value produced by a non-throwing `AsyncGenerator<String>`")
+    func nonThrowingAsyncGeneratorReturnsString() async {
         let result = await call({ "async produced" } as AsyncGenerator<String>)
         #expect(result == "async produced")
     }
     
     
-    @Test("Returns the value produced by a non-throwing `AsyncThrowingGenerator<Point, _>`")
-    func nonThrowingAsyncGeneratorReturnsStruct() async throws {
+    @Test("Returns the value produced by a non-throwing `AsyncGenerator<Point>`")
+    func nonThrowingAsyncGeneratorReturnsStruct() async {
         let expected = Point(x: 11, y: 22)
         let result = await call({ expected } as AsyncGenerator<Point>)
         #expect(result == expected)
@@ -135,10 +136,10 @@ struct CallAsyncGeneratorTests {
     
     
     @available(macOS 15, *)
-    @Test("Can flatten a sequence of `AsyncThrowingGenerator<Int, _>` values iteratively")
-    func flattenSequenceOfAsyncGenerators() async throws {
+    @Test("Can flatten a sequence of `AsyncGenerator<Int>` values iteratively")
+    func flattenSequenceOfAsyncGenerators() async {
         // Mirrors the `map(echo)` pattern from the documentation, adapted for async.
-        let generators: [AsyncGenerator<Int>] = [{ 10 }, { 20 }, { 30 }]
+        let generators: [AsyncGenerator<Int>] = [{ await asyncValue(10) }, { await asyncValue(20) }, { await asyncValue(30) }]
         var results: [Int] = []
         for gen in generators {
             await results.append(call(gen))
@@ -148,7 +149,7 @@ struct CallAsyncGeneratorTests {
     
     
     @Test("Correctly awaits a generator that itself suspends before producing a value")
-    func generatorThatSuspendsIsAwaited() async throws {
+    func generatorThatSuspendsIsAwaited() async {
         // Verifies that `echo` does not short-circuit the async lifecycle —
         // i.e., it genuinely awaits the generator rather than returning prematurely.
         let gen: AsyncGenerator<Int> = {
@@ -176,14 +177,14 @@ struct CallAsyncThrowingGeneratorTests {
     
     @Test("Returns the value produced by a non-throwing `AsyncThrowingGenerator<Int, _>`")
     func nonThrowingAsyncGeneratorReturnsInt() async throws {
-        let result = try await call({ 77 } as AsyncThrowingGenerator<Int, TestError>)
+        let result = try await call({ () throws(TestError) in await asyncValue(77) } as AsyncThrowingGenerator<Int, TestError>)
         #expect(result == 77)
     }
     
     
     @Test("Returns the value produced by a non-throwing `AsyncThrowingGenerator<String, _>`")
     func nonThrowingAsyncGeneratorReturnsString() async throws {
-        let result = try await call({ "async produced" } as AsyncThrowingGenerator<String, TestError>)
+        let result = try await call({ () throws(TestError) in await asyncValue("async produced") } as AsyncThrowingGenerator<String, TestError>)
         #expect(result == "async produced")
     }
     
@@ -191,7 +192,7 @@ struct CallAsyncThrowingGeneratorTests {
     @Test("Returns the value produced by a non-throwing `AsyncThrowingGenerator<Point, _>`")
     func nonThrowingAsyncGeneratorReturnsStruct() async throws {
         let expected = Point(x: 11, y: 22)
-        let result = try await call({ expected } as AsyncThrowingGenerator<Point, TestError>)
+        let result = try await call({ () throws(TestError) in await asyncValue(expected) } as AsyncThrowingGenerator<Point, TestError>)
         #expect(result == expected)
     }
     
@@ -217,7 +218,11 @@ struct CallAsyncThrowingGeneratorTests {
     @Test("Can flatten a sequence of `AsyncThrowingGenerator<Int, _>` values iteratively")
     func flattenSequenceOfAsyncGenerators() async throws {
         // Mirrors the `map(echo)` pattern from the documentation, adapted for async.
-        let generators: [AsyncThrowingGenerator<Int, TestError>] = [{ 10 }, { 20 }, { 30 }]
+        let generators: [AsyncThrowingGenerator<Int, Error>] = [ // TODO: Set this to `TestError` once the compiler doesn't crash doing that
+            { () throws(TestError) in await asyncValue(10) },
+            { () throws(TestError) in await asyncValue(20) },
+            { () throws(TestError) in await asyncValue(30) }
+        ]
         var results: [Int] = []
         for gen in generators {
             try await results.append(call(gen))
@@ -230,7 +235,7 @@ struct CallAsyncThrowingGeneratorTests {
     func generatorThatSuspendsIsAwaited() async throws {
         // Verifies that `echo` does not short-circuit the async lifecycle —
         // i.e., it genuinely awaits the generator rather than returning prematurely.
-        let gen: AsyncThrowingGenerator<Int, TestError> = {
+        let gen: AsyncThrowingGenerator<Int, TestError> = { () throws(TestError) in
             await Task.yield()
             return 42
         }

--- a/Tests/FunctionToolsTests/`echo` tests.swift
+++ b/Tests/FunctionToolsTests/`echo` tests.swift
@@ -250,15 +250,6 @@ struct EchoSyncGeneratorTests {
 
 // MARK: - echo<T>(_ value: T) -> AsyncGenerator<T>
 
-private func asyncValue<T: Sendable>(_ value: T) async -> T {
-    await Task {
-        try? await Task.sleep(for: .milliseconds(.random(in: 0...15)))
-        return value
-    }
-    .value
-}
-
-
 private var asyncValue_42: Int { get async {
     await asyncValue(42)
 }}
@@ -323,7 +314,7 @@ struct EchoAsyncGeneratorTests {
         let point = Point(x: 8, y: 16)
         let gen: AsyncGenerator<Point> = await echo(asyncValue(point))
         let result = await gen()
-        #expect(await result == point)
+        #expect(result == point)
     }
     
     

--- a/Tests/FunctionToolsTests/test utilities.swift
+++ b/Tests/FunctionToolsTests/test utilities.swift
@@ -8,6 +8,17 @@
 import Foundation
 
 
+// MARK: - value transformers
+
+func asyncValue<T: Sendable>(_ value: T) async -> T {
+    await Task {
+        try? await Task.sleep(for: .milliseconds(.random(in: 0...15)))
+        return value
+    }
+    .value
+}
+
+
 
 // MARK: - data structures
 


### PR DESCRIPTION
Applying this to existing function types and `call` functions