### PR TITLE
Converted `blackhole` and `null` to parameter packs

### DIFF
--- a/Sources/FunctionTools/Blackholes.swift
+++ b/Sources/FunctionTools/Blackholes.swift
@@ -8,17 +8,9 @@
 
 
 
-/// This guarantees that even the most scrutinous of optimizers will never optimize-away these blackholes
-private nonisolated(unsafe) var blackholeAcceptor: Any? { //unsafe: Since this does nothing with the data, the concept of data safety doesn't apply anyway. Marking this as nonisolated eases the compiler's concerns about safe concurrency.
-    didSet {
-        blackholeAcceptor = nil
-    }
-}
-
-
 /// A function which does nothing, but will never be optimized away. Useful for testing.
 ///
-/// - SeeAlso: `null`
+/// - SeeAlso: ``null(_:)`` for a version that's always optimized-out
 @inline(never)
 @Sendable
 public func blackhole() -> Void { }
@@ -41,63 +33,9 @@ public func blackhole() -> Void { }
 /// }
 /// ```
 ///
-/// - Parameter a: Anything at all
+/// The parameters can be anything at all
 ///
-/// - SeeAlso: `null`
+/// - SeeAlso: ``null(_:)`` for a version that's ALWAYS optimized-out
 @inline(never)
 @Sendable
-public func blackhole<A>(_ a: A) -> Void { blackholeAcceptor = a }
-
-
-/// A function which takes two values and does nothing with them, but will never be optimized away. Useful for testing.
-///
-/// - Parameters:
-///     - a: Anything at all
-///     - b: Anything at all
-///
-/// - SeeAlso: `null`
-@inline(never)
-@Sendable
-public func blackhole<A, B>(_ a: A, _ b: B) -> Void { blackholeAcceptor = (a, b) }
-
-
-/// A function which takes three values and does nothing with them, but will never be optimized away. Useful for testing.
-///
-/// - Parameters:
-///     - a: Anything at all
-///     - b: Anything at all
-///     - c: Anything at all
-///
-/// - SeeAlso: `null`
-@inline(never)
-@Sendable
-public func blackhole<A, B, C>(_ a: A, _ b: B, _ c: C) -> Void { blackholeAcceptor = (a, b, c) }
-
-
-/// A function which takes four values and does nothing with them, but will never be optimized away. Useful for testing.
-///
-/// - Parameters:
-///     - a: Anything at all
-///     - b: Anything at all
-///     - c: Anything at all
-///     - d: Anything at all
-///
-/// - SeeAlso: `null`
-@inline(never)
-@Sendable
-public func blackhole<A, B, C, D>(_ a: A, _ b: B, _ c: C, _ d: D) -> Void { blackholeAcceptor = (a, b, c, d) }
-
-
-/// A function which takes five values and does nothing with them, but will never be optimized away. Useful for testing.
-///
-/// - Parameters:
-///     - a: Anything at all
-///     - b: Anything at all
-///     - c: Anything at all
-///     - d: Anything at all
-///     - e: Anything at all
-///
-/// - SeeAlso: `null`
-@inline(never)
-@Sendable
-public func blackhole<A, B, C, D, E>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E) -> Void { blackholeAcceptor = (a, b, c, d, e) }
+public func blackhole<each Ignored>(_: repeat each Ignored) -> Void { }

--- a/Sources/FunctionTools/Null functions.swift
+++ b/Sources/FunctionTools/Null functions.swift
@@ -11,7 +11,7 @@
 /// A function which does nothing, and will always be optimized away. Useful for when another function needs to take a
 /// callback but you have nothing to do when it calls it.
 ///
-/// - SeeAlso: `blackhole`
+/// - SeeAlso: ``blackhole(_:)`` for a version that's NEVER optimized-out
 @inline(__always)
 @Sendable
 public func null() { }
@@ -25,68 +25,9 @@ public func null() { }
 /// myObject.someAsyncFunction(onComplete: null)
 /// ```
 ///
-/// - Parameter a: Anything at all
+/// The parameters can be anything at all
 ///
-/// - SeeAlso: `blackhole`
+/// - SeeAlso: ``blackhole(_:)`` for a version that's NEVER optimized-out
 @inline(__always)
 @Sendable
-public func null<A>(_ a: A) { }
-
-
-/// A function which takes two values and does nothing with them, and will always be optimized away. Useful for when
-/// another function needs to take a callback but you have nothing to do when it calls it.
-///
-/// - Parameters:
-///     - a: Anything at all
-///     - b: Anything at all
-///
-/// - SeeAlso: `blackhole`
-@inline(__always)
-@Sendable
-public func null<A, B>(_ a: A, _ b: B) { }
-
-
-/// A function which takes three values and does nothing with them, and will always be optimized away. Useful for when
-/// another function needs to take a callback but you have nothing to do when it calls it.
-///
-/// - Parameters:
-///     - a: Anything at all
-///     - b: Anything at all
-///     - c: Anything at all
-///
-/// - SeeAlso: `blackhole`
-@inline(__always)
-@Sendable
-public func null<A, B, C>(_ a: A, _ b: B, _ c: C) { }
-
-
-/// A function which takes four values and does nothing with them, and will always be optimized away. Useful for when
-/// another function needs to take a callback but you have nothing to do when it calls it.
-///
-/// - Parameters:
-///     - a: Anything at all
-///     - b: Anything at all
-///     - c: Anything at all
-///     - d: Anything at all
-///
-/// - SeeAlso: `blackhole`
-@inline(__always)
-@Sendable
-public func null<A, B, C, D>(_ a: A, _ b: B, _ c: C, _ d: D) { }
-
-
-/// A function which takes five values and does nothing with them, and will always be optimized away. Useful for when
-/// another function needs to take a callback but you have nothing to do when it calls it.
-///
-/// - Parameters:
-///     - a: Anything at all
-///     - b: Anything at all
-///     - c: Anything at all
-///     - d: Anything at all
-///     - e: Anything at all
-///
-/// - SeeAlso: `blackhole`
-@inline(__always)
-@Sendable
-public func null<A, B, C, D, E>(_ a: A, _ b: B, _ c: C, _ d: D, _ e: E) { }
-
+public func null<each Ignored>(_: repeat each Ignored) { }

--- a/Tests/FunctionToolsTests/`blackhole`.swift
+++ b/Tests/FunctionToolsTests/`blackhole`.swift
@@ -1,0 +1,72 @@
+//
+//  blackhole tests.swift
+//  FunctionTools
+//
+//  Created by Ky on 2026-06-23.
+//
+
+import Testing
+
+import FunctionTools
+
+
+
+@Suite("`blackhole` tests")
+struct blackhole_Test {
+    
+    @Test("`blackhole` handles 1 parameters")
+    func blackhole_1parameters() async throws {
+        let (a) = (1)
+        blackhole(a)
+        #expect((1) == (a))
+    }
+    
+    
+    @Test("`blackhole` handles 2 parameters")
+    func blackhole_2parameters() async throws {
+        let (a, b) = (1, "2")
+        blackhole(a, b)
+        #expect((1, "2") == (a, b))
+    }
+    
+    
+    @Test("`blackhole` handles 3 parameters")
+    func blackhole_3parameters() async throws {
+        let (a, b, c) = (1, "2", 3.4)
+        blackhole(a, b, c)
+        #expect((1, "2", 3.4) == (a, b, c))
+    }
+    
+    
+    @Test("`blackhole` handles 4 parameters")
+    func blackhole_4parameters() async throws {
+        let (a, b, c, d) = (1, "2", 3.4, true)
+        blackhole(a, b, c, d)
+        #expect((1, "2", 3.4, true) == (a, b, c, d))
+    }
+    
+    
+    @Test("`blackhole` handles 5 parameters")
+    func blackhole_5parameters() async throws {
+        let (a, b, c, d, e) = (1, "2", 3.4, true, uuid)
+        blackhole(a, b, c, d, e)
+        #expect((1, "2", 3.4, true, uuid) == (a, b, c, d, e))
+    }
+    
+    
+    @Test("`blackhole` handles 6 parameters")
+    func blackhole_6parameters() async throws {
+        let (a, b, c, d, e, f) = (1, "2", 3.4, true, uuid, #function)
+        blackhole(a, b, c, d, e, f)
+        #expect((1, "2", 3.4, true, uuid, #function) == (a, b, c, d, e, f))
+    }
+    
+    
+    @Test("`blackhole` handles 7 parameters")
+    func blackhole_7parameters() async throws {
+        let (a, b, c, d, e, f, g) = (1, "2", 3.4, true, uuid, #function, [1, 2, 3])
+        blackhole(a, b, c, d, e, f, g)
+        #expect((1, "2", 3.4, true, uuid, #function) == (a, b, c, d, e, f))
+        #expect([1, 2, 3] == g) // Blackhole now handles arbitrary parameter counts, but `==` only handles tuples up to 6 items wide – Ky, 2026-06-23
+    }
+}

--- a/Tests/FunctionToolsTests/`null`.swift
+++ b/Tests/FunctionToolsTests/`null`.swift
@@ -1,0 +1,72 @@
+//
+//  null tests.swift
+//  FunctionTools
+//
+//  Created by Ky on 2026-06-23.
+//
+
+import Testing
+
+import FunctionTools
+
+
+
+@Suite("`null` tests")
+struct null_Test {
+    
+    @Test("`null` handles 1 parameters")
+    func null_1parameters() async throws {
+        let (a) = (1)
+        null(a)
+        #expect((1) == (a))
+    }
+    
+    
+    @Test("`null` handles 2 parameters")
+    func null_2parameters() async throws {
+        let (a, b) = (1, "2")
+        null(a, b)
+        #expect((1, "2") == (a, b))
+    }
+    
+    
+    @Test("`null` handles 3 parameters")
+    func null_3parameters() async throws {
+        let (a, b, c) = (1, "2", 3.4)
+        null(a, b, c)
+        #expect((1, "2", 3.4) == (a, b, c))
+    }
+    
+    
+    @Test("`null` handles 4 parameters")
+    func null_4parameters() async throws {
+        let (a, b, c, d) = (1, "2", 3.4, true)
+        null(a, b, c, d)
+        #expect((1, "2", 3.4, true) == (a, b, c, d))
+    }
+    
+    
+    @Test("`null` handles 5 parameters")
+    func null_5parameters() async throws {
+        let (a, b, c, d, e) = (1, "2", 3.4, true, uuid)
+        null(a, b, c, d, e)
+        #expect((1, "2", 3.4, true, uuid) == (a, b, c, d, e))
+    }
+    
+    
+    @Test("`null` handles 6 parameters")
+    func null_6parameters() async throws {
+        let (a, b, c, d, e, f) = (1, "2", 3.4, true, uuid, #function)
+        null(a, b, c, d, e, f)
+        #expect((1, "2", 3.4, true, uuid, #function) == (a, b, c, d, e, f))
+    }
+    
+    
+    @Test("`null` handles 7 parameters")
+    func null_7parameters() async throws {
+        let (a, b, c, d, e, f, g) = (1, "2", 3.4, true, uuid, #function, [1, 2, 3])
+        null(a, b, c, d, e, f, g)
+        #expect((1, "2", 3.4, true, uuid, #function) == (a, b, c, d, e, f))
+        #expect([1, 2, 3] == g) // Blackhole now handles arbitrary parameter counts, but `==` only handles tuples up to 6 items wide – Ky, 2026-06-23
+    }
+}

--- a/Tests/FunctionToolsTests/test utilities.swift
+++ b/Tests/FunctionToolsTests/test utilities.swift
@@ -37,3 +37,11 @@ struct Point: Equatable {
 
 /// A reference type used to verify that identity (===) is preserved when something is handed a class instance.
 final class Token {}
+
+
+
+// MARK: - values
+
+/// One UUID which is guaranteed to remain the same value per test runtime
+let uuid = UUID()
+


### PR DESCRIPTION
This allows callers to pass an arbitrary amount of parameters to these functions without us defining arbitrary amounts of function signatures to take all those parameters.

Also testing them! Not much to test, so mostly just guaranteeing it compiles and doesn't change anything.
